### PR TITLE
rely on object destructor to close db

### DIFF
--- a/tests/001-basic.phpt
+++ b/tests/001-basic.phpt
@@ -5,10 +5,7 @@ leveldb - basic: get(), set(), put(), delete()
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
-$leveldb_path = dirname(__FILE__) . '/leveldb-basic.test-db';
+$leveldb_path = __DIR__ . '/leveldb-basic.test-db';
 $db = new LevelDB($leveldb_path);
 
 var_dump($db->set('key', 'value'));
@@ -18,6 +15,11 @@ var_dump($db->put('name', 'reeze'));
 var_dump($db->get('name'));
 var_dump($db->delete('name'));
 var_dump($db->get('name'));
+?>
+--CLEAN--
+<?php
+$leveldb_path = __DIR__ . '/leveldb-basic.test-db';
+LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
 bool(true)

--- a/tests/002-db-management.phpt
+++ b/tests/002-db-management.phpt
@@ -9,7 +9,7 @@ $path = dirname(__FILE__) . '/leveldb-db-op.test-db';
 $db = new LevelDB($path);
 $db->set("key", "value");
 
-$db->close();
+unset($db);
 var_dump(LevelDB::destroy($path));
 var_dump(file_exists($path));
 ?>

--- a/tests/004-write-batch.phpt
+++ b/tests/004-write-batch.phpt
@@ -5,9 +5,6 @@ leveldb - write batch
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_batch.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -31,6 +28,11 @@ var_dump($db->write($batch));
 
 var_dump($db->get('batch_foo2'));
 var_dump($db->get('batch_foo'));
+?>
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_batch.test-db';
+LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
 * batch write with setting

--- a/tests/005-iterator.phpt
+++ b/tests/005-iterator.phpt
@@ -5,9 +5,6 @@ leveldb - iterate through db
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_iterator.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -63,6 +60,11 @@ $it->next();
 var_dump($it->current());
 
 var_dump($it->getError());
+?>
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_iterator.test-db';
+LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
 *** Loop through ***

--- a/tests/006-iterator-foreach.phpt
+++ b/tests/006-iterator-foreach.phpt
@@ -5,9 +5,6 @@ leveldb - iterate through db by foreach
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_iterator-foreach.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -31,6 +28,11 @@ echo "*** Loop through in foreach with newly-created iterator ***\n";
 foreach(new LevelDBIterator($db) as $key => $value){
 	echo "{$key} => {$value}\n";
 }
+?>
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_iterator-foreach.test-db';
+LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
 *** Loop through in foreach style ***

--- a/tests/007-db-close.phpt
+++ b/tests/007-db-close.phpt
@@ -5,47 +5,24 @@ leveldb - db close
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_close.test-db';
 $db = new LevelDB($leveldb_path);
 
-$db->set("key", "value");
-
-$it = new LevelDBIterator($db);
-
-$db->close();
 $db->close();
 
-try {
-	$db->set("new-key", "value");
-} catch(LevelDBException $e) {
-	echo $e->getMessage() . "\n";
-}
 
-try {
-	$it->next();
-} catch(LevelDBException $e) {
-	echo $e->getMessage() . "\n";
-}
+unset($it);
+unset($db);
 
-try{
-	$it->rewind();
-}catch(LevelDBException $e){
-	echo $e->getMessage() . "\n";
-}
-
-try{
-	foreach($it as $key => $value){
-		echo "$key => $value\n";
-	}
-}catch(LevelDBException $e){
-	echo $e->getMessage() . "\n";
-}
+// ensure destructeur properly close the db */
+LevelDB::destroy($leveldb_path);
+var_dump(file_exists($leveldb_path));
+?>
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_close.test-db';
+if (file_exists($leveldb_path)) LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
-Can not operate on closed db
-Can not iterate on closed db
-Iterator has been destroyed
-Iterator has been destroyed
+Deprecated: %s LevelDB::close() is deprecated in %s
+bool(false)

--- a/tests/008-options.phpt
+++ b/tests/008-options.phpt
@@ -5,9 +5,6 @@ leveldb - options open options
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_options.test-db';
 
 try {
@@ -24,7 +21,7 @@ try {
 	echo $e->getMessage() . "\n";
 }
 
-$db->close();
+unset($db);
 try {
 	$db = new LevelDB($leveldb_path, array("error_if_exists" => true));
 } catch(LevelDBException $e) {
@@ -32,6 +29,11 @@ try {
 }
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_options.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 Invalid argument: %s: does not exist (create_if_missing is false)
 string(5) "value"

--- a/tests/009-comparator.phpt
+++ b/tests/009-comparator.phpt
@@ -5,14 +5,11 @@ leveldb - custom comparator
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-comparator.test-db';
 
 echo "*** could not use invalid custom comparator ***\n";
 try {
-	$db2 = new LevelDB($leveldb_path, array('comparator' => 'invaid_func'));
+	$db = new LevelDB($leveldb_path, array('comparator' => 'invaid_func'));
 } catch(LevelDBException $e) {
 	echo $e->getMessage() . "\n";
 }
@@ -29,32 +26,30 @@ $it = new LevelDBIterator($db);
 foreach($it as $v) {
 	echo "$v\n";
 }
-
-$db->close();
+unset($it);
+unset($db);
 
 echo "*** custom comparator can only open with the same comparator again ***\n";
 try {
-	$db2 = new LevelDB($leveldb_path);
+	$db = new LevelDB($leveldb_path);
 } catch(LevelDBException $e) {
 	echo $e->getMessage() . "\n";
 }
 
-$db2 = new LevelDB($leveldb_path, array('comparator' => 'custom_comparator'));
-var_dump($db2->get(1) == 1);
 
-$db2->close();
+$db = new LevelDB($leveldb_path, array('comparator' => 'custom_comparator'));
+var_dump($db->get(1) == 1);
+unset($db);
 
 
 echo "*** custom comparator which throw exception ***\n";
-$db3 = new LevelDB($leveldb_path, array('comparator' => array('CustomFunc', 'willException')));
+$db = new LevelDB($leveldb_path, array('comparator' => array('CustomFunc', 'willException')));
 try {
-	$db3->set("Hi", "guys");
-	var_dump($db3->get("Hi"));
+	$db->set("Hi", "guys");
+	var_dump($db->get("Hi"));
 } catch(Exception $e) {
 	echo $e->getMessage() . "\n";
 }
-
-$db3->close();
 
 // reverse DESC
 function custom_comparator($a, $b) {
@@ -71,6 +66,11 @@ class CustomFunc {
 }
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-comparator.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 *** could not use invalid custom comparator ***
 Invalid open option: comparator, invaid_func() is not callable

--- a/tests/010-compression.phpt
+++ b/tests/010-compression.phpt
@@ -5,20 +5,21 @@ leveldb - compression
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-compression.test-db';
 
 $db = new LevelDB($leveldb_path, array('compression' => 33));
-$db->close();
+unset($db);
 
-$db2 = new LevelDB($leveldb_path, array('compression' => LEVELDB_SNAPPY_COMPRESSION));
-$db2->set("key", "value");
+$db = new LevelDB($leveldb_path, array('compression' => LEVELDB_SNAPPY_COMPRESSION));
+$db->set("key", "value");
 
-$db2->close();
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-compression.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 Warning: LevelDB::__construct(): Unsupported compression type in %s on line %s
 ==DONE==

--- a/tests/011-getApproximateSizes.phpt
+++ b/tests/011-getApproximateSizes.phpt
@@ -5,9 +5,6 @@ leveldb - getApproximateSizes
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-getApproximateSizes.test-db';
 
 $db = new LevelDB($leveldb_path);
@@ -15,7 +12,7 @@ for($i=0; $i < 99999; ++$i) {
 	$db->set("b{$i}", "value");
 }
 
-$db->close();
+unset($db);
 
 $db = new LevelDB($leveldb_path);
 
@@ -24,6 +21,11 @@ var_dump($db->getApproximateSizes(array(), array()));
 var_dump($db->getApproximateSizes(array("a", "b"), array("c", "Z")));
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-getApproximateSizes.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 Warning: LevelDB::getApproximateSizes(): The num of start keys and limit keys didn't match in %s on line %d
 bool(false)

--- a/tests/012-getProperty.phpt
+++ b/tests/012-getProperty.phpt
@@ -5,9 +5,6 @@ leveldb - getProperty
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-getProperty.test-db';
 
 $db = new LevelDB($leveldb_path);
@@ -30,6 +27,11 @@ var_dump($db->getProperty('leveldb.anything'));
 var_dump($db->getProperty('anythingelse'));
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-getProperty.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 bool(true)
 bool(true)

--- a/tests/013-compactRange.phpt
+++ b/tests/013-compactRange.phpt
@@ -5,9 +5,6 @@ leveldb - compactRange
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-compactRange.test-db';
 
 $db = new LevelDB($leveldb_path);
@@ -18,6 +15,11 @@ for($i=0; $i < 99999; ++$i) {
 var_dump($db->compactRange('a', 'Z'));
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-compactRange.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 NULL
 ==DONE==

--- a/tests/014-iterator-destroy.phpt
+++ b/tests/014-iterator-destroy.phpt
@@ -5,9 +5,6 @@ leveldb - iterator destroy
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_iterator_destroy.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -22,6 +19,11 @@ try {
 }
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_iterator_destroy.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 Iterator has been destroyed
 ==DONE==

--- a/tests/015-double-iterator.phpt
+++ b/tests/015-double-iterator.phpt
@@ -5,9 +5,6 @@ leveldb - Fixed bug segfault when double construct iterator
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_iterator_double_construct.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -18,5 +15,10 @@ $it1->destroy();
 $it2->destroy();
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_iterator_double_construct.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 ==DONE==

--- a/tests/016-different-iterators-should-differ.phpt
+++ b/tests/016-different-iterators-should-differ.phpt
@@ -5,9 +5,6 @@ leveldb - different iterators should not affect each other
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_iterator_should_not_affect_eachother.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -32,6 +29,11 @@ $it1->destroy();
 $it2->destroy();
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_iterator_should_not_affect_eachother.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 1 => 1
 2 => 2

--- a/tests/017-db-getIterator.phpt
+++ b/tests/017-db-getIterator.phpt
@@ -5,9 +5,6 @@ leveldb - LevelDB::getIterator()
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb_get_iterator.test-db';
 $db = new LevelDB($leveldb_path);
 
@@ -22,6 +19,11 @@ var_dump(get_class($it));
 for ($it->rewind(); $it->valid(); $it->next()) {
 	echo $it->key() . " => " . $it->current() . "\n";
 }
+?>
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb_get_iterator.test-db';
+LevelDB::destroy($leveldb_path);
 ?>
 --EXPECTF--
 string(15) "LevelDBIterator"

--- a/tests/018-snapshot.phpt
+++ b/tests/018-snapshot.phpt
@@ -5,9 +5,6 @@ leveldb - snapshot
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/leveldb-snapshot.test-db';
 @unlink($leveldb_path);
 
@@ -47,6 +44,11 @@ try {
 }
 ?>
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/leveldb-snapshot.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECTF--
 string(69) "Invalid snapshot parameter, it must be an instance of LevelDBSnapshot"
 key1 => value1

--- a/tests/019-null-comparator.phpt
+++ b/tests/019-null-comparator.phpt
@@ -8,9 +8,6 @@ open with null shouldn't throw exception
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/null-comparator.test-db';
 
 $db = new LevelDB($leveldb_path, array('comparator' => NULL));
@@ -18,6 +15,11 @@ $db = new LevelDB($leveldb_path, array('comparator' => NULL));
 ?>
 Should no exception
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/null-comparator.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECT--
 Should no exception
 ==DONE==

--- a/tests/020-null-snapshot.phpt
+++ b/tests/020-null-snapshot.phpt
@@ -5,9 +5,6 @@ leveldb - NULL snapshot should not throw exception
 --FILE--
 <?php
 
-include "leveldb.inc";
-cleanup_leveldb_on_shutdown();
-
 $leveldb_path = dirname(__FILE__) . '/null-snapshot.test-db';
 
 $db = new LevelDB($leveldb_path);
@@ -17,6 +14,11 @@ var_dump($db->get("key", array('snapshot' => NULL)));
 ?>
 Should no exception
 ==DONE==
+--CLEAN--
+<?php
+$leveldb_path = dirname(__FILE__) . '/null-snapshot.test-db';
+LevelDB::destroy($leveldb_path);
+?>
 --EXPECT--
 bool(false)
 Should no exception

--- a/tests/leveldb.inc
+++ b/tests/leveldb.inc
@@ -1,19 +1,5 @@
 <?php
 
-function cleanup_leveldb_on_shutdown() {
-	register_shutdown_function('cleanup_leveldb');
-}
-
-function cleanup_leveldb() {
-	global $leveldb_path, $db;
-	if (file_exists($leveldb_path)) {
-		if($db instanceof LevelDB) {
-			$db->close();
-		}
-		LevelDB::destroy($leveldb_path);
-	}
-}
-
 function leveldb_empty($db) {
 	$it = new LevelDBIterator($db);
 


### PR DESCRIPTION
As explain in #36 

PHP_VERSION : **7.3.22**

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   15
---------------------------------------------------------------------

Number of tests :   20                20
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :   20 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    5 seconds
=====================================================================

```

PHP_VERSION : **8.0.0beta4** (with pr #40)

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   16
---------------------------------------------------------------------

Number of tests :   20                20
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   20 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    5 seconds
=====================================================================

```
