### PR TITLE
Fix reopen cleanup in PHP LevelDB

### DIFF
--- a/leveldb.c
+++ b/leveldb.c
@@ -640,9 +640,20 @@ PHP_METHOD(LevelDB, __construct)
 
 	intern = LEVELDB_OBJ_FROM_ZV(getThis());
 
-	if (intern->db) {
-		leveldb_close(intern->db);
-	}
+        if (intern->db) {
+                leveldb_close(intern->db);
+                intern->db = NULL;
+        }
+
+        if (intern->comparator) {
+                leveldb_comparator_destroy(intern->comparator);
+                intern->comparator = NULL;
+        }
+
+        if (intern->callable_name) {
+                zend_string_release(intern->callable_name);
+                intern->callable_name = NULL;
+        }
 
 	openoptions = php_leveldb_get_open_options(options_zv, &intern->comparator, &intern->callable_name);
 

--- a/tests/021-reopen.phpt
+++ b/tests/021-reopen.phpt
@@ -1,0 +1,34 @@
+--TEST--
+leveldb - reopen cleans up old resources
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+$path1 = __DIR__ . '/reopen1.test-db';
+$path2 = __DIR__ . '/reopen2.test-db';
+
+$db = new LevelDB($path1, array('comparator' => 'custom_comparator'));
+$db->set('foo', 'bar');
+
+// Reopen the same object with a new database
+$db->__construct($path2);
+var_dump($db->get('foo')); // should be false since new DB is empty
+
+function custom_comparator($a, $b) {
+    if ($a == $b) {
+        return 0;
+    }
+    return ($a > $b) ? -1 : 1;
+}
+?>
+==DONE==
+--CLEAN--
+<?php
+$path1 = __DIR__ . '/reopen1.test-db';
+$path2 = __DIR__ . '/reopen2.test-db';
+LevelDB::destroy($path1);
+LevelDB::destroy($path2);
+?>
+--EXPECT--
+bool(false)
+==DONE==


### PR DESCRIPTION
## Summary
- ensure comparator and callable resources are released when reopening a DB
- reset internal DB pointer to avoid double close
- add regression test for reopening

## Testing
- `make test TESTS=tests/021-reopen.phpt`
- `make test TESTS=tests`


------
https://chatgpt.com/codex/tasks/task_e_683fca06d404832785bd2dd1bf232737