### PR TITLE
Fix reopen cleanup in PHP LevelDB

### DIFF
--- a/tests/021-reopen.phpt
+++ b/tests/021-reopen.phpt
@@ -1,0 +1,34 @@
+--TEST--
+leveldb - reopen cleans up old resources
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+$path1 = __DIR__ . '/reopen1.test-db';
+$path2 = __DIR__ . '/reopen2.test-db';
+
+$db = new LevelDB($path1, array('comparator' => 'custom_comparator'));
+$db->set('foo', 'bar');
+
+// Reopen the same object with a new database
+$db->__construct($path2);
+var_dump($db->get('foo')); // should be false since new DB is empty
+
+function custom_comparator($a, $b) {
+    if ($a == $b) {
+        return 0;
+    }
+    return ($a > $b) ? -1 : 1;
+}
+?>
+==DONE==
+--CLEAN--
+<?php
+$path1 = __DIR__ . '/reopen1.test-db';
+$path2 = __DIR__ . '/reopen2.test-db';
+LevelDB::destroy($path1);
+LevelDB::destroy($path2);
+?>
+--EXPECT--
+bool(false)
+==DONE==

--- a/tests/022-block-cache.phpt
+++ b/tests/022-block-cache.phpt
@@ -1,0 +1,26 @@
+--TEST--
+leveldb - block_cache_size releases on reopen
+--SKIPIF--
+<?php include 'skipif.inc'; ?>
+--FILE--
+<?php
+$path1 = __DIR__ . '/cache1.test-db';
+$path2 = __DIR__ . '/cache2.test-db';
+
+$db = new LevelDB($path1, array('block_cache_size' => 1024 * 1024));
+$db->set('foo', 'bar');
+
+$db->__construct($path2, array('block_cache_size' => 1024 * 1024));
+var_dump($db->get('foo'));
+?>
+==DONE==
+--CLEAN--
+<?php
+$path1 = __DIR__ . '/cache1.test-db';
+$path2 = __DIR__ . '/cache2.test-db';
+LevelDB::destroy($path1);
+LevelDB::destroy($path2);
+?>
+--EXPECT--
+bool(false)
+==DONE==


### PR DESCRIPTION
## Summary
- ensure comparator and callable resources are released when reopening a DB
- reset internal DB pointer to avoid double close
- free block cache objects on reopen or error
- add test for block_cache_size reopen logic

## Testing
- `make test TESTS=tests/022-block-cache.phpt`
- `make test TESTS=tests`

------
https://chatgpt.com/codex/tasks/task_e_683fca06d404832785bd2dd1bf232737