### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/leveldb.c
+++ b/leveldb.c
@@ -1578,7 +1578,7 @@ PHP_METHOD(LevelDBSnapshot, release)
 PHP_MINIT_FUNCTION(leveldb)
 {
 	zend_class_entry ce;
-	zend_class_entry *exception_ce = zend_exception_get_default();
+	zend_class_entry *exception_ce = zend_ce_exception;
 
 #define DECLARE_OBJ_HANDLERS(class_type) \
 	memcpy(& class_type##_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers)); \


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5